### PR TITLE
各コンポーネントのtypeの名前がキャメルケースになっているものをパスカルケースに修正しました。

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,15 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     //これがないと、 error 'React' must be in scope when using JSXと怒られる。
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+
+    // Typeはパスカルケースでないとエラーを出す。
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "typeAlias",
+        "format": ["PascalCase"]
+      }
+    ]
   }
 }

--- a/src/component/Button.tsx
+++ b/src/component/Button.tsx
@@ -6,13 +6,13 @@ import { memo } from "react";
 import type { ReactNode } from "react";
 import type { FC } from "react";
 
-type props = {
+type Props = {
   onClickEvent: React.MouseEventHandler<HTMLButtonElement>;
   children: ReactNode;
 };
 
 //Buttonコンポーネントに型をつける。
-export const Button: FC<props> = memo((props) => {
+export const Button: FC<Props> = memo((props) => {
   const { onClickEvent } = props;
   const StyledButton = styled.button`
     color: black;

--- a/src/component/Image.tsx
+++ b/src/component/Image.tsx
@@ -1,9 +1,9 @@
 import type { FC } from "react";
-type props = {
+type Props = {
   url: string;
 };
 
-export const Image: FC<props> = (props) => {
+export const Image: FC<Props> = (props) => {
   const { url } = props;
   return (
     <div>

--- a/src/component/LinkText.tsx
+++ b/src/component/LinkText.tsx
@@ -7,12 +7,12 @@ import { memo } from "react"; //LinkTextコンポーネントのメモ化
 import type { ReactNode } from "react";
 import type { FC } from "react";
 
-type props = {
+type Props = {
   destination: string;
   children: ReactNode;
 };
 
-export const LinkText: FC<props> = memo((props) => {
+export const LinkText: FC<Props> = memo((props) => {
   const { destination } = props;
   const linkstyle = css`
     font-size: 20px;

--- a/src/component/pages/TodoList.tsx
+++ b/src/component/pages/TodoList.tsx
@@ -60,8 +60,8 @@ export const TodoList = () => {
     }
   `;
 
+  // 登録したTodoを格納した変数incompleteTodosをグローバルStateから取得
   const { incompleteTodos } = useContext(TodoContext);
-
   // カスタムHookから変数useImage,関数imageFetchを取得
   const { textTitle, jsonFetch } = useTextGet();
   // カスタムHookから関数deleteTodoを取得

--- a/src/component/pages/TodoRegister.tsx
+++ b/src/component/pages/TodoRegister.tsx
@@ -29,7 +29,6 @@ export const TodoRegister: FC = () => {
   const { apiPokemonBack, imageFetch } = useImageGet();
   // カスタムHookから変数apiPokemonBack,,関数imageFetchを取得
   const { todoFetch, valueFetch, startDayFetch, endDayFetch } = useAddTodos();
-
   // グローバルStateの変数群を取り出す。
   const { newTodo, startDate, endDate } = useContext(TodoContext);
 

--- a/src/hook/useDeletTodo.ts
+++ b/src/hook/useDeletTodo.ts
@@ -4,10 +4,6 @@ import { useContext } from "react";
 import { TodoContext } from "../component/provider/TodoProvider";
 import { useCallback } from "react";
 
-// type Index = {
-//   index: number;
-// };
-
 export const useDeleteTodo = () => {
   // グローバルStateの変数を引き出す
   const { incompleteTodos, setIncompleteTodos } = useContext(TodoContext);

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -5,14 +5,13 @@ import { TopPage } from "../component/pages/TopPage";
 import { Page404 } from "../component/pages/Page404";
 import type { ReactNode } from "react";
 
+// インポートしたオブジェクトの型 →exportの外に記述
+type MapTypes = {
+  path: string;
+  children: ReactNode; //childrenはコンポーネントを指すのでReactNode型を指定
+};
+
 export const Router = () => {
-  // インポートしたオブジェクトの型
-
-  type MapTypes = {
-    path: string;
-    children: ReactNode; //childrenはコンポーネントを指すのでReactNode型を指定
-  };
-
   return (
     <Routes>
       {/* react router v6 doesn't support exact anymore. exactは使わない*/}

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from "react";
 export const Router = () => {
   // インポートしたオブジェクトの型
 
-  type mapTypes = {
+  type MapTypes = {
     path: string;
     children: ReactNode; //childrenはコンポーネントを指すのでReactNode型を指定
   };
@@ -18,8 +18,8 @@ export const Router = () => {
       {/* react router v6 doesn't support exact anymore. exactは使わない*/}
       <Route path="" element={<TopPage />} />
       <Route path="todoregister">
-        {/* Map関数の展開した値：route1に型：mapTypesをつける */}
-        {TodoRegisterRoutes.map((route1: mapTypes) => (
+        {/* Map関数の展開した値：route1に型：MapTypesをつける */}
+        {TodoRegisterRoutes.map((route1: MapTypes) => (
           <Route
             key={route1.path}
             path={`${route1.path}`}
@@ -28,8 +28,8 @@ export const Router = () => {
         ))}
       </Route>
       <Route path="todolist">
-        {/* Map関数の展開した値：route２に型：mapTypesをつける */}
-        {TodoListRoutes.map((route2: mapTypes) => (
+        {/* Map関数の展開した値：route２に型：MapTypesをつける */}
+        {TodoListRoutes.map((route2: MapTypes) => (
           <Route
             key={route2.path}
             path={`${route2.path}`}


### PR DESCRIPTION
### Issue
[型定義の命名規則について＃6](https://github.com/macmeals/todo_context_typescript/issues/6)

### **内容**
❶パスカルケースになっていないTypeの名前をEslintで検出するため、.eslintrc.jsonに以下のルールを追加。
変更したファイル　「.eslintrc.json」
`"rules": {
// Typeはパスカルケースでないとエラーを出す。
    "@typescript-eslint/naming-convention": [
      "error",
      {
        "selector": "typeAlias",
        "format": ["PascalCase"]
      }
    ]
  }`

❷以下のComponetの中にあったキャメルケースの（パスカルケースになっていない）Typeの名前をパスカルケースに変更
- Button.tsx　　　　　　　　　　Type props      →     Type Props 
- Image.tsx            　　　　　　　Type props      →     Type Props 
- LinkText.tsx       　　　　　　  　Type props     →      Type Props
- Router.tsx         　　　　　　　  Type mapTypes　→     Type MapTypes





