### PR TITLE
TopPage.tsxのLinkコンポーネントをLinkTextコンポーネントに修正しました。

### DIFF
--- a/src/component/pages/TopPage.tsx
+++ b/src/component/pages/TopPage.tsx
@@ -3,7 +3,7 @@
 
 import { FC } from "react";
 import { css } from "@emotion/react";
-import { Link } from "react-router-dom";
+import { LinkText } from "../LinkText";
 
 //日付用ライブラリ：react-day-pickerをインポート
 import { DayPicker } from "react-day-picker"; //react-day-picker v8.0.５
@@ -22,7 +22,7 @@ export const TopPage: FC = () => {
     <div>
       <div css={topStyles}>
         <h1>Todoアプリ</h1>
-        <Link to="/todoregister">Todo登録</Link>
+        <LinkText destination={"/todoregister"}>Todo登録</LinkText>
         <DayPicker />
       </div>
     </div>


### PR DESCRIPTION
### Issue
[Issue9](https://github.com/macmeals/todo_context_typescript/issues/9)

### 内容
TopPage.tsxのLinkコンポーネントをLinkTextコンポーネントに修正しました。
```
import { LinkText } from "../LinkText";

<LinkText destination={"/todoregister"}>Todo登録</LinkText>
```
