### PR TITLE
react-day-picker のCSSのimport文をApp.tsxに集約しました。

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,9 @@ import { css, keyframes } from "@emotion/react";
 import { BrowserRouter } from "react-router-dom";
 import { Router } from "./router/Router";
 
+//react-day-picker v8.0.5のCSSはこちらで読み込む
+import "react-day-picker/dist/style.css";
+
 export const App = () => {
   const headerStyles = css({
     textAlign: "center",

--- a/src/component/pages/TodoRegister.tsx
+++ b/src/component/pages/TodoRegister.tsx
@@ -10,7 +10,6 @@ import { FC } from "react";
 
 //日付用ライブラリ：react-day-pickerをインポート
 import { DayPicker } from "react-day-picker"; // v8.0.５
-import "react-day-picker/dist/style.css"; // v8.0.5
 
 //message用ライブラリ：react-hot-toastをインポート
 import { Toaster } from "react-hot-toast";

--- a/src/component/pages/TopPage.tsx
+++ b/src/component/pages/TopPage.tsx
@@ -7,7 +7,6 @@ import { LinkText } from "../LinkText";
 
 //日付用ライブラリ：react-day-pickerをインポート
 import { DayPicker } from "react-day-picker"; //react-day-picker v8.0.５
-import "react-day-picker/dist/style.css"; //react-day-picker v8.0.5
 
 export const TopPage: FC = () => {
   //TypeScriptでEmotionのCSSを記載。


### PR DESCRIPTION
### Isuee
[＃１０](https://github.com/macmeals/todo_context_typescript/issues/10)

### 内容
App.tsxに以下を記述し、TopPage.tsx、TodoRegister.tsxから以下の記述を削除
`import "react-day-picker/dist/style.css";`